### PR TITLE
Refactor ideas

### DIFF
--- a/scripts/updateMessages.js
+++ b/scripts/updateMessages.js
@@ -1,12 +1,12 @@
 const fetchSpeechToText = async (url) => {
   // getting translated message from storage.local
-  let savedUrls = await browser.storage.local.get();
+  /** @type {Record<string, string>} */
+  const savedUrls = await browser.storage.local.get();
 
   if (savedUrls) {
-    for (let savedUrl in savedUrls) {
-      if (savedUrl === url) {
-        return savedUrls[savedUrl];
-      }
+    const cachedMessage = savedUrls[url];
+    if (cachedMessage) {
+      return cachedMessage;
     }
   }
 
@@ -14,13 +14,13 @@ const fetchSpeechToText = async (url) => {
   // TODO: fetch sererUrl from heroku server
   const serverUrl = "http://61e2-78-11-176-160.ngrok.io";
 
-  const headers = {
+  const requestOptions = {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ url: url }),
+    body: JSON.stringify({ url }),
   };
 
-  const response = await fetch(serverUrl + "/speech-to-text", headers);
+  const response = await fetch(serverUrl + "/speech-to-text", requestOptions);
 
   const message = await response.text();
 
@@ -28,24 +28,34 @@ const fetchSpeechToText = async (url) => {
     savedUrls[url] = message;
     browser.storage.local.set(savedUrls);
   } else {
-    browser.storage.local.set({ url: message });
+    browser.storage.local.set({ [url]: message });
   }
 
   return message;
 };
 
+// TODO: use `MutationObserver` instead of polling
+// See https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
 setInterval(() => {
   const list = document.getElementsByClassName(
     "aovydwv3 j83agx80 cbu4d94t d2edcug0 l9j0dhe7"
   );
 
   for (let element of list) {
-    if (element.getElementsByTagName("audio").length > 0) {
-      const url = element.getElementsByTagName("audio")[0].getAttribute("src");
-      fetchSpeechToText(url).then(
-        (message) =>
-          (element.innerHTML = `<span class="tojvnm2t a6sixzi8 abs2jz4q a8s20v7p t1p8iaqh k5wvi7nf q3lfd5jv pk4s997a bipmatt0 cebpdrjk qowsmv63 owwhemhu dp1hu0rb dhp61c6y iyyx5f41"><div role="none" class="j83agx80 k4urcfbm"><div role="none" class="ns4p8fja j83agx80 cbu4d94t a6sixzi8 bkfpd7mw d2edcug0 buofh1pr nred35xi"><div role="none" class="buofh1pr rj1gh0hx"></div></div><div role="none" class="l60d2q6s d1544ag0 sj5x9vvc tw6a2znq l9j0dhe7 ni8dbmo4 stjgntxs e72ty7fz qlfml3jp inkptoze qmr60zad jm1wdb64 qv66sw1b ljqsnud1 odn2s2vf tkr6xdv7" style="background-color: rgb(96, 96, 96);"><div role="none" class="rq0escxv l9j0dhe7 du4w35lb __fb-dark-mode"><div role="none" class="ljqsnud1 ii04i59q" dir="auto">${message}</div></div></div></div></span>`)
-      );
+    const audioElement = element.querySelector("audio");
+    if (!audioElement) {
+      continue;
     }
+
+    const url = audioElement.getAttribute("src");
+    fetchSpeechToText(url).then((message) => {
+      element.innerHTML = createMessengerTextMessage(message);
+    });
   }
 }, 1000);
+
+/**
+ * @param {string} text
+ */
+const createMessengerTextMessage = (text) =>
+  `<span class="tojvnm2t a6sixzi8 abs2jz4q a8s20v7p t1p8iaqh k5wvi7nf q3lfd5jv pk4s997a bipmatt0 cebpdrjk qowsmv63 owwhemhu dp1hu0rb dhp61c6y iyyx5f41"><div role="none" class="j83agx80 k4urcfbm"><div role="none" class="ns4p8fja j83agx80 cbu4d94t a6sixzi8 bkfpd7mw d2edcug0 buofh1pr nred35xi"><div role="none" class="buofh1pr rj1gh0hx"></div></div><div role="none" class="l60d2q6s d1544ag0 sj5x9vvc tw6a2znq l9j0dhe7 ni8dbmo4 stjgntxs e72ty7fz qlfml3jp inkptoze qmr60zad jm1wdb64 qv66sw1b ljqsnud1 odn2s2vf tkr6xdv7" style="background-color: rgb(96, 96, 96);"><div role="none" class="rq0escxv l9j0dhe7 du4w35lb __fb-dark-mode"><div role="none" class="ljqsnud1 ii04i59q" dir="auto">${text}</div></div></div></div></span>`;


### PR DESCRIPTION
This PR contains a couple of refactor ideas split into 2 commits. You may want to review this PR commit by commit for better clarity :smile: 

The first commit contains small code style refactors. All of them are described in the commit message.

The second commit introduces a higher order function for memoization (i.e. caching). This is to separate the business logic (fetching the message text from the network) from the memoization boilerplate. I hope this improves code readability :smile:

## Other ideas

I would suggest starting to use TypeScript :smile: Maybe not write the TypeScript code, but at least install typings for the `browser` global variable, so you get autocomplete as you type (ATM the `browser` global variable is not defined in my IDE :smile: )

I have found https://github.com/Lusito/webextension-polyfill-ts but I believe that may require adding a build step (some bundler) because it uses ES modules (it has an `import` statement).